### PR TITLE
[CVE-2023-22320] Fix path traversal vulnerability

### DIFF
--- a/source/am.h
+++ b/source/am.h
@@ -13,6 +13,9 @@
  *
  * Copyright 2014 - 2016 ForgeRock AS.
  */
+/**
+ * Portions Copyrighted 2022 OGIS-RI Co., Ltd.
+ */
 
 #ifndef AM_H
 #define AM_H
@@ -248,6 +251,7 @@ typedef struct am_request {
     struct url url; /* parsed/normalized request url (split in values) */
     char *normalized_url; /* normalized request url */
     char *overridden_url; /* normalized/overridden request url */
+    char *goto_url; /* URL based on overridden_url but using orig_url only for path information */
     char *normalized_url_pathinfo;
     char *overridden_url_pathinfo;
     const char *cookies;

--- a/source/process.c
+++ b/source/process.c
@@ -13,6 +13,9 @@
  *
  * Copyright 2014 - 2016 ForgeRock AS.
  */
+/**
+ * Portions Copyrighted 2022 OGIS-RI Co., Ltd.
+ */
 
 #include "platform.h"
 #include "am.h"
@@ -222,6 +225,41 @@ char *remove_pathinfo_from_url(struct url *url, const char *pathinfo) {
     return out;
 }
 
+char *get_goto_url(const char *orig_url, struct url *url) {
+    char org_path[AM_URI_SIZE + 1];
+    char *goto_url = NULL;
+    char *p, *q;
+
+    memset(org_path, 0, sizeof(org_path));
+    p = strstr(orig_url, "://");
+    if (p != NULL) {
+        p = strstr(p + 3, "/");
+        if (p != NULL) {
+            q = org_path;
+            int l = sizeof(org_path) - 1;
+            for (int i = 0; i < l; i++) {
+                if (*p != '\0' && *p != '?' && *p != '#') {
+                    *q++ = *p++;
+                } else {
+                    break;
+                }
+            }
+        } else {
+            org_path[0] = '/';
+        }
+    } else {
+        return NULL;
+    }
+
+    am_asprintf(&goto_url, "%s://%s:%d%s%s", url->proto, url->host,
+            url->port, org_path, url->query);
+    if (goto_url == NULL) {
+        return NULL;
+    }
+
+    return goto_url;
+}
+
 static am_return_t setup_request_data(am_request_t *r) {
     static const char *thisfunc = "setup_request_data():";
     am_status_t status = AM_ERROR, status_token_query = AM_ERROR;
@@ -365,6 +403,12 @@ static am_return_t setup_request_data(am_request_t *r) {
         return AM_FAIL;
     }
 
+    r->goto_url = get_goto_url(r->orig_url, &request_url);
+    if (r->goto_url == NULL) {
+        AM_LOG_ERROR(r->instance_id, "%s failed to make goto_url", thisfunc);
+        return AM_FAIL;
+    }
+
     if (ISVALID(r->path_info) && r->conf->path_info_ignore) {
         r->overridden_url_pathinfo = remove_pathinfo_from_url(&request_url, r->path_info);
         if (r->overridden_url_pathinfo == NULL) {
@@ -381,11 +425,11 @@ static am_return_t setup_request_data(am_request_t *r) {
 
     AM_LOG_DEBUG(r->instance_id, "%s \nmethod: %s \noriginal url: %s"
             "\nproto: %s\nhost: %s\nport: %d\npath: %s\nquery: %s\ncomplete: %s\noverridden: %s"
-            "\npathinfo: %s"
+            "\ngoto_url: %s\npathinfo: %s"
             "\nnormalized (pathinfo removed): %s\noverridden (pathinfo removed): %s", thisfunc,
             am_method_num_to_str(r->method), r->orig_url,
             r->url.proto, r->url.host, r->url.port, r->url.path, r->url.query, r->normalized_url,
-            r->overridden_url, LOGEMPTY(r->path_info),
+            r->overridden_url, r->goto_url, LOGEMPTY(r->path_info),
             LOGEMPTY(r->normalized_url_pathinfo), LOGEMPTY(r->overridden_url_pathinfo));
 
     if (r->method == AM_REQUEST_POST && !ISVALID(r->content_type)) {
@@ -1995,7 +2039,7 @@ static char *find_active_login_server(am_request_t *r, char add_goto_value) {
     if (map_sz > 0 && map != NULL) {
         am_config_map_t *m = (valid_idx >= map_sz) ? &map[0] : &map[valid_idx];
         if (add_goto_value) {
-            char *goto_encoded = url_encode(r->overridden_url);
+            char *goto_encoded = url_encode(r->goto_url);
 
             if (r->conf->cdsso_enable &&
                     ISVALID(r->conf->url_redirect_param) &&
@@ -2606,7 +2650,7 @@ static am_return_t handle_exit(am_request_t *r) {
                     }
 
                 } else if (ISVALID(r->conf->access_denied_url)) {
-                    char *goto_encoded = url_encode(r->overridden_url);
+                    char *goto_encoded = url_encode(r->goto_url);
 
                     am_asprintf(&url, "%s%s%s=%s", r->conf->access_denied_url,
                             strchr(r->conf->access_denied_url, '?') == NULL ? "?" : "&",

--- a/source/utility.c
+++ b/source/utility.c
@@ -13,6 +13,9 @@
  *
  * Copyright 2014 - 2016 ForgeRock AS.
  */
+/**
+ * Portions Copyrighted 2022 OGIS-RI Co., Ltd.
+ */
 
 #include "platform.h"
 #include "am.h"
@@ -549,7 +552,7 @@ int parse_url(const char *u, struct url *url) {
         }
     }
 
-    d = strdup(url->path);
+    d = url_decode(url->path);
     if (d == NULL) {
         url->error = AM_ENOMEM;
         return AM_ERROR;
@@ -2017,7 +2020,7 @@ void decrypt_agent_passwords(am_config_t *r) {
 void am_request_free(am_request_t *r) {
     if (r != NULL) {
         AM_FREE(r->normalized_url, r->overridden_url, r->normalized_url_pathinfo,
-                r->overridden_url_pathinfo, r->token,
+                r->overridden_url_pathinfo, r->token, r->goto_url,
                 r->client_ip, r->client_host, r->post_data, r->post_data_fn,
                 r->session_info.s1, r->session_info.si, r->session_info.sk);
         delete_am_policy_result_list(&r->pattr);


### PR DESCRIPTION
This PR fixes security vulnerability published as a [CVE-2023-22320](https://nvd.nist.gov/vuln/detail/CVE-2023-22320).

Credits for the fix go to [OpenAM Consortium ](https://github.com/openam-jp).